### PR TITLE
Fix changed GPG keyserver address for RHEL UBI base image building

### DIFF
--- a/pytroll_base_image/build_dir/Dockerfile_rhel_ubi
+++ b/pytroll_base_image/build_dir/Dockerfile_rhel_ubi
@@ -5,7 +5,7 @@ RUN microdnf update && \
     microdnf clean all
 
 ENV GOSU_VERSION=1.11
-RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+RUN gpg --keyserver keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
     && curl -o /usr/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" \
     && curl -o /usr/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc" \
     && gpg --verify /usr/bin/gosu.asc \


### PR DESCRIPTION
The keyserver earlier `gosu` installation used for RHEL UBI varoamt of the `pytroll_base_image` doesn't work anymore, and this changes the server to a working one.