### PR TITLE
Use Mambaforge instead of Miniconda

### DIFF
--- a/README
+++ b/README
@@ -11,7 +11,7 @@ Currently available images:
 
     - the base image used for all the other images.  Includes only the
       operating system (Red Hat Enterprise Linux and Ubuntu as
-      options) and the base installation of Miniconda3
+      options) and the base installation of Mambaforge
 
   trollmoves
 

--- a/pytroll_base_image/README
+++ b/pytroll_base_image/README
@@ -42,6 +42,6 @@ c) Confirm the build succeeded
 
   and the command
 
-    docker run -it pytroll_base_image echo "success"
+    docker run -it --rm pytroll_base_image echo "success"
 
   should print "success" to the terminal.

--- a/pytroll_base_image/build_dir/Dockerfile_rhel_ubi
+++ b/pytroll_base_image/build_dir/Dockerfile_rhel_ubi
@@ -15,14 +15,11 @@ RUN gpg --keyserver keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C2
     # Verify that the binary works
     && gosu nobody true
 
-RUN curl -o Miniconda3-latest-Linux-x86_64.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    sh Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \
-    rm Miniconda3-latest-Linux-x86_64.sh && \
+RUN curl -L -o Mambaforge-latest-Linux-x86_64.sh https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh && \
+    sh Mambaforge-latest-Linux-x86_64.sh -b -p /opt/conda && \
+    rm Mambaforge-latest-Linux-x86_64.sh && \
     echo ". /opt/conda/etc/profile.d/conda.sh" >> /root/.bashrc && \
     echo "conda activate base" >> /root/.bashrc && \
     source /root/.bashrc && \
-    conda config --add channels conda-forge && \
-    conda config --set channel_priority true && \
-    conda update -n base -c conda-forge conda && \
-    conda install -c conda-forge mamba && \
-    mamba update -c conda-forge --all
+    mamba update -n base conda && \
+    mamba update --all

--- a/pytroll_base_image/build_dir/Dockerfile_ubuntu
+++ b/pytroll_base_image/build_dir/Dockerfile_ubuntu
@@ -1,11 +1,15 @@
-FROM continuumio/miniconda3:latest
+FROM ubuntu:latest
 
 RUN apt-get update && apt-get -y --no-install-recommends install \
-    gosu
+    gosu \
+    curl \
+    ca-certificates
 
-RUN conda config --add channels conda-forge && \
-    conda config --set channel_priority true && \
-    conda update -n base -c defaults conda && \
-    conda install -c conda-forge mamba && \
-    mamba update -c conda-forge --all && \
-    conda clean -a -y
+RUN curl -L -o Mambaforge-latest-Linux-x86_64.sh https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh && \
+    sh Mambaforge-latest-Linux-x86_64.sh -b -p /opt/conda && \
+    rm Mambaforge-latest-Linux-x86_64.sh && \
+    echo ". /opt/conda/etc/profile.d/conda.sh" >> /root/.bashrc && \
+    echo "conda activate base" >> /root/.bashrc && \
+    . /root/.bashrc && \
+    mamba update -n base conda && \
+    mamba update --all

--- a/trollflow2_full_image/build_dir/Dockerfile_stable
+++ b/trollflow2_full_image/build_dir/Dockerfile_stable
@@ -1,7 +1,7 @@
 FROM pytroll_base_image
 
 RUN . /root/.bashrc && \
-    mamba install -c conda-forge satpy \
+    mamba install satpy \
     pyresample \
     pykdtree \
     trollimage \

--- a/trollmoves/build_dir/Dockerfile_stable
+++ b/trollmoves/build_dir/Dockerfile_stable
@@ -1,7 +1,7 @@
 FROM pytroll_base_image
 
 RUN . /root/.bashrc && \
-    mamba install -c conda-forge \
+    mamba install \
     pyinotify \
     trollsift \
     netifaces \


### PR DESCRIPTION
Due to changes in Terms of Service of Anaconda Inc., I swapped these images to use Mambaforge instead of Miniconda3. To simplify things, I also made the Ubuntu variant of Pytroll base image to use the official Ubuntu image.