### PR TITLE
Prevent installation of Conda version that breaks Mamba

### DIFF
--- a/pytroll_base_image/build_dir/Dockerfile_rhel_ubi
+++ b/pytroll_base_image/build_dir/Dockerfile_rhel_ubi
@@ -21,6 +21,6 @@ RUN curl -L -o Mambaforge-latest-Linux-x86_64.sh https://github.com/conda-forge/
     echo ". /opt/conda/etc/profile.d/conda.sh" >> /root/.bashrc && \
     echo "conda activate base" >> /root/.bashrc && \
     source /root/.bashrc && \
-    mamba update -n base conda && \
-    mamba update --all && \
+    mamba update -y -n base 'conda!=4.13.0' && \
+    mamba update -y --all && \
     mamba clean -a -y

--- a/pytroll_base_image/build_dir/Dockerfile_ubuntu
+++ b/pytroll_base_image/build_dir/Dockerfile_ubuntu
@@ -11,6 +11,6 @@ RUN curl -L -o Mambaforge-latest-Linux-x86_64.sh https://github.com/conda-forge/
     echo ". /opt/conda/etc/profile.d/conda.sh" >> /root/.bashrc && \
     echo "conda activate base" >> /root/.bashrc && \
     . /root/.bashrc && \
-    mamba update -n base conda && \
-    mamba update --all && \
+    mamba update -y -n base 'conda!=4.13.0' && \
+    mamba update -y --all && \
     mamba clean -a -y


### PR DESCRIPTION
This PR prevents upgrading Conda to version 4.13.0 that breaks Mamba.

Closes #6 